### PR TITLE
[記事詳細ページ] NILTOでもmicroCMSと同じように記事詳細を表示できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,3 +126,20 @@ schedule:
 
 オンにしたい場合は`app/layout.tsx`内のスクリプト読み込み部分と、`app/_components/Ad/index.tsx`内のコメントアウトを解除してください。
 その際には、`data-ad-client`などの値は Adsense から取得してきた値に適宜変更してください。
+
+## 2024/07/30 追記
+
+2024/07/30 feature/nilto-fetch-and-display-article-details ブランチの時点での`.env.local`ファイルは以下のようになっています。
+
+```
+NEXT_PUBLIC_MICROCMS_GET_API_KEY=xxxxx
+NEXT_PUBLIC_MICROCMS_SERVICE_DOMAIN=xxxxx
+BASE_URL=http://localhost:3000/
+# NEXT_PUBLIC_GTM_ID=GTM-xxxxxxxx
+
+NEXT_PUBLIC_NILTO_API_KEY=xxxxx
+NEXT_PUBLIC_NILTO_BASE_URL=https://cms-api.nilto.com/v1/
+
+# MEMO: nilto or microcms
+NEXT_PUBLIC_TYPE_CMS=nilto
+```

--- a/app/_components/Card/index.tsx
+++ b/app/_components/Card/index.tsx
@@ -1,37 +1,51 @@
 import Link from 'next/link';
 import { Article } from '@/_libs/microcms';
 import PublishDate from '@/_components/PublishDate';
-import { Card, CardActionArea, CardContent, CardMedia, Typography, CardActions, Button } from '@mui/material';
+import {
+  Card,
+  CardActionArea,
+  CardContent,
+  CardMedia,
+  Typography,
+  CardActions,
+  Button,
+} from '@mui/material';
 
 type Props = {
-    article: Article;
+  article:
+    | Article // TODO: すべてのページでmicrocmsとniltoの切り替え対応が完了後、型Articleは不要になるはずなので削除する
+    | {
+        id: string;
+        title: string;
+        description: string;
+        thumbnail: {
+          url: string;
+        };
+        publishedAt?: string | null;
+        createdAt: string;
+      };
 };
 
 export default function CustomCard({ article }: Props) {
-    return (
-        <Card>
-            <CardActionArea component={Link} href={`/articles/${article.id}`}>
-                <CardMedia
-                    component="img"
-                    height="140"
-                    image={article.thumbnail.url}
-                    alt=""
-                />
-                <CardContent>
-                    <Typography gutterBottom variant="h5" component="div">
-                        {article.title}
-                    </Typography>
-                    <Typography variant="body2" color="text.secondary">
-                        {article.description}
-                    </Typography>
-                </CardContent>
-            </CardActionArea>
-            <CardActions sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                <PublishDate date={article.publishedAt || article.createdAt} />
-                <Button size="small" color="primary">
-                    Share
-                </Button>
-            </CardActions>
-        </Card>
-    );
+  return (
+    <Card>
+      <CardActionArea component={Link} href={`/articles/${article.id}`}>
+        <CardMedia component="img" height="140" image={article.thumbnail.url} alt="" />
+        <CardContent>
+          <Typography gutterBottom variant="h5" component="div">
+            {article.title}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {article.description}
+          </Typography>
+        </CardContent>
+      </CardActionArea>
+      <CardActions sx={{ display: 'flex', justifyContent: 'space-between' }}>
+        <PublishDate date={article.publishedAt || article.createdAt} />
+        <Button size="small" color="primary">
+          Share
+        </Button>
+      </CardActions>
+    </Card>
+  );
 }

--- a/app/_components/Cards/index.tsx
+++ b/app/_components/Cards/index.tsx
@@ -3,7 +3,18 @@ import CustomCard from '@/_components/Card';
 import { Grid } from '@mui/material';
 
 type Props = {
-  articles: Article[];
+  articles:
+    | Article[] // TODO: すべてのページでmicrocmsとniltoの切り替え対応が完了後、型Articleは不要になるはずなので削除する
+    | {
+        id: string;
+        title: string;
+        description: string;
+        thumbnail: {
+          url: string;
+        };
+        publishedAt?: string | null;
+        createdAt: string;
+      }[];
 };
 
 export default function Cards({ articles }: Props) {
@@ -11,12 +22,12 @@ export default function Cards({ articles }: Props) {
     return <p>記事がありません。</p>;
   }
   return (
-      <Grid container spacing={4}>
-        {articles.map((article) => (
-            <Grid item xs={12} sm={6} md={4} key={article.id}>
-              <CustomCard article={article} />
-            </Grid>
-        ))}
-      </Grid>
+    <Grid container spacing={4}>
+      {articles.map((article) => (
+        <Grid item xs={12} sm={6} md={4} key={article.id}>
+          <CustomCard article={article} />
+        </Grid>
+      ))}
+    </Grid>
   );
 }

--- a/app/_components/Category/index.tsx
+++ b/app/_components/Category/index.tsx
@@ -2,7 +2,7 @@ import { Category } from '@/_libs/microcms';
 import Link from 'next/link';
 
 type Props = {
-  category: Category;
+  category: { id: string; name: string };
 };
 
 export default function Category({ category }: Props) {

--- a/app/_components/Tag/index.tsx
+++ b/app/_components/Tag/index.tsx
@@ -2,7 +2,7 @@ import { Tag } from '@/_libs/microcms';
 import Link from 'next/link';
 
 type Props = {
-  tag: Tag;
+  tag: { id: string; name: string };
 };
 
 export default function Tag({ tag }: Props) {

--- a/app/_components/Tags/index.tsx
+++ b/app/_components/Tags/index.tsx
@@ -3,7 +3,7 @@ import Tag from '@/_components/Tag';
 import styles from './index.module.css';
 
 type Props = {
-  tags: TagType[];
+  tags: { id: string; name: string }[];
 };
 
 export default function Tags({ tags }: Props) {

--- a/app/_libs/anti-corruption-layer/articleDetail.ts
+++ b/app/_libs/anti-corruption-layer/articleDetail.ts
@@ -1,0 +1,172 @@
+import { Article, getArticleDetail } from '../microcms';
+import { ArticleDetailResponse, fetchArticleDetail } from '../nilto/articleDetail';
+import { TYPE_CMS, TypeCMS } from '../utils';
+
+// 記事詳細の型定義
+export type TransformedArticleDetailResponse = {
+  id: string;
+  title: string;
+  description: string;
+  publishedAt?: string | null;
+  createdAt: string;
+  thumbnail: {
+    url: string;
+    width: number;
+    height: number;
+  };
+  category: {
+    id: string;
+    name: string;
+  } | null;
+  tags: {
+    id: string;
+    name: string;
+  }[];
+  content: {
+    fieldId: string;
+    richEditor?: string;
+    ad?: boolean;
+  }[];
+  relatedArticles: {
+    id: string;
+    title: string;
+    description: string;
+    thumbnail: {
+      url: string;
+    };
+    publishedAt?: string | null;
+    createdAt: string;
+  }[];
+};
+
+// 指定されたCMSから記事詳細を取得する
+export const fetchArticleDetailCMSData = async (
+  typeCMS: TypeCMS,
+  id: string,
+  draftKey?: string,
+) => {
+  switch (typeCMS) {
+    case 'nilto':
+      return await fetchArticleDetail(id);
+    case 'microcms':
+      return await getArticleDetail(id, {
+        draftKey: draftKey,
+      });
+    default:
+      throw new Error('Unsupported CMS type');
+  }
+};
+
+const createThumbnail = (url: string, width: number = 800, height: number = 600) => ({
+  url,
+  width,
+  height,
+});
+
+const transformNiltoData = (niltoData: ArticleDetailResponse): TransformedArticleDetailResponse => {
+  const content: { fieldId: string; richEditor?: string; ad?: boolean }[] = [];
+
+  niltoData.content.forEach((item) => {
+    if (item.luid === 'rich_editor') {
+      content.push({
+        fieldId: 'richEditor',
+        richEditor: item.fields.rich_editor,
+      });
+    } else if (item.luid === 'ad') {
+      content.push({
+        fieldId: 'ad',
+        ad: item.fields.ad,
+      });
+    }
+  });
+
+  return {
+    id: niltoData._id.toString(),
+    title: niltoData.title,
+    description: niltoData.description,
+    publishedAt: niltoData._published_at,
+    createdAt: niltoData._created_at,
+    thumbnail: createThumbnail(niltoData.thumbnail.url),
+    category: {
+      id: niltoData.category._id.toString(),
+      name: niltoData.category.name,
+    },
+    tags: niltoData.tags.map((tag) => ({
+      id: tag.tag._id.toString(),
+      name: tag.tag.name,
+    })),
+    content: content,
+    relatedArticles: niltoData.related_articles.map((article) => ({
+      id: article.related_article._id.toString(),
+      title: article.related_article.title,
+      description: article.related_article.description,
+      thumbnail: {
+        url: article.related_article.thumbnail.url,
+      },
+      publishedAt: article.related_article._published_at,
+      createdAt: article.related_article._created_at,
+    })),
+  };
+};
+
+const transformMicroCMSData = (microCMSData: Article): TransformedArticleDetailResponse => ({
+  id: microCMSData.id,
+  title: microCMSData.title,
+  description: microCMSData.description,
+  publishedAt: microCMSData.publishedAt,
+  createdAt: microCMSData.createdAt,
+  thumbnail: createThumbnail(
+    microCMSData.thumbnail.url,
+    microCMSData.thumbnail.width,
+    microCMSData.thumbnail.height,
+  ),
+  category: microCMSData.category
+    ? {
+        id: microCMSData.category.id,
+        name: microCMSData.category.name,
+      }
+    : null,
+  tags: microCMSData.tags.map((tag) => ({
+    id: tag.id,
+    name: tag.name,
+  })),
+  content: microCMSData.content,
+  relatedArticles: microCMSData.relatedArticles.map((article) => ({
+    id: article.id,
+    title: article.title,
+    description: article.description,
+    thumbnail: {
+      url: article.thumbnail.url,
+    },
+    publishedAt: article.publishedAt,
+    createdAt: article.createdAt,
+  })),
+});
+
+export const transformResponse = (
+  data: ArticleDetailResponse | Article,
+  typeCMS: TypeCMS,
+): TransformedArticleDetailResponse => {
+  switch (typeCMS) {
+    case 'nilto':
+      return transformNiltoData(data as ArticleDetailResponse);
+    case 'microcms':
+      return transformMicroCMSData(data as Article);
+    default:
+      throw new Error('Unsupported CMS type');
+  }
+};
+
+// 記事詳細を取得してデータを変換して返す
+export const fetchArticleDetailData = async (
+  slug: string,
+  draftKey?: string,
+): Promise<TransformedArticleDetailResponse> => {
+  const response = await fetchArticleDetailCMSData(TYPE_CMS, slug, draftKey);
+
+  if (!response) {
+    throw new Error('Failed to fetch article details');
+  }
+
+  return transformResponse(response, TYPE_CMS);
+};

--- a/app/_libs/nilto/articleDetail.ts
+++ b/app/_libs/nilto/articleDetail.ts
@@ -1,0 +1,78 @@
+type Category = {
+  _id: number;
+  name: string;
+};
+
+type Tag = {
+  _id: number;
+  name: string;
+};
+
+type Thumbnail = {
+  url: string;
+};
+
+type ContentFields = {
+  rich_editor?: string;
+  ad?: boolean;
+};
+
+type Content = {
+  luid: string;
+  fields: ContentFields;
+};
+
+type RelatedArticle = {
+  _id: number;
+  _created_at: string;
+  _published_at: string | null; // MEMO: 下書きの記事ではnullになる
+  title: string;
+  description: string;
+  thumbnail: Thumbnail;
+};
+
+export type ArticleDetailResponse = {
+  _id: number;
+  _created_at: string;
+  _published_at: string | null; // MEMO: 下書きの記事ではnullになる
+  title: string;
+  description: string;
+  category: Category;
+  tags: { tag: Tag }[];
+  thumbnail: Thumbnail;
+  content: Content[];
+  related_articles: { related_article: RelatedArticle }[];
+};
+
+const baseUrl = process.env.NEXT_PUBLIC_NILTO_BASE_URL;
+const apiKey = process.env.NEXT_PUBLIC_NILTO_API_KEY;
+
+if (!baseUrl) {
+  throw new Error('NEXT_PUBLIC_NILTO_BASE_URL is required');
+}
+
+if (!apiKey) {
+  throw new Error('NEXT_PUBLIC_NILTO_API_KEY is required');
+}
+
+export const fetchArticleDetail = async (
+  articleId: string,
+): Promise<ArticleDetailResponse | null> => {
+  try {
+    const headers = new Headers();
+    headers.append('X-NILTO-API-KEY', apiKey);
+
+    const response = await fetch(`${baseUrl}contents/${articleId}`, {
+      headers: headers,
+    });
+
+    if (!response) {
+      throw new Error('Failed to fetch article details');
+    }
+
+    const data: ArticleDetailResponse = await response.json();
+    return data;
+  } catch (error) {
+    return null;
+  }
+};

--- a/app/_libs/utils.ts
+++ b/app/_libs/utils.ts
@@ -1,6 +1,10 @@
 import { format } from 'date-fns';
 import { utcToZonedTime } from 'date-fns-tz';
 
+export const TYPE_CMS = process.env.NEXT_PUBLIC_TYPE_CMS as TypeCMS;
+
+export type TypeCMS = 'nilto' | 'microcms';
+
 export const formatDate = (date: string) => {
   const utcDate = new Date(date);
   const jstDate = utcToZonedTime(utcDate, 'Asia/Tokyo');

--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -1,6 +1,5 @@
-import {Metadata} from 'next';
+import { Metadata } from 'next';
 import Image from 'next/image';
-import {getArticleDetail} from '@/_libs/microcms';
 import Layout from '@/_components/Layout';
 import Main from '@/_components/Main';
 import Sub from '@/_components/Sub';
@@ -13,83 +12,80 @@ import SearchField from '@/_components/SearchField';
 import Category from '@/_components/Category';
 import Tags from '@/_components/Tags';
 import Cards from '@/_components/Cards';
-import styles from './page.module.css'
+import styles from './page.module.css';
+import { fetchArticleDetailData } from '@/_libs/anti-corruption-layer/articleDetail';
 
 type Props = {
-    params: {
-        slug: string;
-    };
-    searchParams: {
-        draftKey?: string;
-    };
+  params: {
+    slug: string;
+  };
+  searchParams: {
+    draftKey?: string;
+  };
 };
 
 export const revalidate = 60;
 
-export async function generateMetadata({params, searchParams}: Props): Promise<Metadata> {
-    const data = await getArticleDetail(params.slug, {
-        draftKey: searchParams.draftKey,
-    });
+export async function generateMetadata({ params, searchParams }: Props): Promise<Metadata> {
+  const data = await fetchArticleDetailData(params.slug, searchParams.draftKey);
 
-    return {
-        title: data.title,
-        description: data.description,
-        openGraph: {
-            title: data.title,
-            description: data.description,
-            images: data.thumbnail.url,
-        },
-    };
+  return {
+    title: data.title,
+    description: data.description,
+    openGraph: {
+      title: data.title,
+      description: data.description,
+      images: data.thumbnail.url,
+    },
+  };
 }
 
-export default async function Page({params, searchParams}: Props) {
-    const data = await getArticleDetail(params.slug, {
-        draftKey: searchParams.draftKey,
-    });
+export default async function Page({ params, searchParams }: Props) {
+  const data = await fetchArticleDetailData(params.slug, searchParams.draftKey);
 
-    return (
-        <Layout>
-            <Main>
-                <div className={styles.container}>
-                    <div className={styles.content}>
-                        <h1 className={styles.title}>{data.title}</h1>
-                        <div>カテゴリー：{data.category && <Category category={data.category}/>}</div>
-                        <div>タグ：{data.tags && <Tags tags={data.tags}/>}</div>
-                        <div>
-                            <PublishDate date={data.publishedAt || data.createdAt}/>
-                        </div>
-                        <div className={styles.thumbnail}>
-                            <Image
-                                src={data.thumbnail.url}
-                                alt=""
-                                width={data.thumbnail.width}
-                                height={data.thumbnail.height}
-                            />
-                        </div>
-                        {data.content.map((item, i) => {
-                            if (item.fieldId === 'richEditor') {
-                                return <RichEditor key={i} content={item.richEditor}/>;
-                            }
-                            if (item.fieldId === 'ad' && item.ad) {
-                                return <Ad key={i}/>;
-                            }
-                            return null;
-                        })}
-                        {data.relatedArticles.length > 0 && (
-                            <>
-                                <h2>関連記事</h2>
-                                <Cards articles={data.relatedArticles}/>
-                            </>
-                        )}
-                    </div>
-                </div>
-            </Main>
-            <Sub>
-                <Ad/>
-                <Pickup/>
-                <SearchField/>
-                <Ranking/>
-            </Sub>
-        </Layout>
-    );
+  return (
+    <Layout>
+      <Main>
+        <div className={styles.container}>
+          <div className={styles.content}>
+            <h1 className={styles.title}>{data.title}</h1>
+            <div>カテゴリー：{data.category && <Category category={data.category} />}</div>
+            <div>タグ：{data.tags && <Tags tags={data.tags} />}</div>
+            <div>
+              <PublishDate date={data.publishedAt || data.createdAt} />
+            </div>
+            <div className={styles.thumbnail}>
+              <Image
+                src={data.thumbnail.url}
+                alt=""
+                width={data.thumbnail.width}
+                height={data.thumbnail.height}
+              />
+            </div>
+            {data.content.map((item, i) => {
+              if (item.fieldId === 'richEditor' && item.richEditor) {
+                return <RichEditor key={i} content={item.richEditor} />;
+              }
+              if (item.fieldId === 'ad' && item.ad) {
+                return <Ad key={i} />;
+              }
+              return null;
+            })}
+            {data.relatedArticles.length > 0 && (
+              <>
+                <h2>関連記事</h2>
+                <Cards articles={data.relatedArticles} />
+              </>
+            )}
+          </div>
+        </div>
+      </Main>
+      <Sub>
+        <Ad />
+        <Pickup />
+        <SearchField />
+        <Ranking />
+      </Sub>
+    </Layout>
+  );
 }

--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,7 @@ const nextConfig = {
         hostname: 'images.microcms-assets.io',
       },
     ],
+    domains: ['cms-assets.nilto.com'],
   },
 };
 


### PR DESCRIPTION
## 関連Issue
### #12 詳細ページ - ブロック機能を使ってテンプレートを複数作成する
#### このPRでできていること
- [x] 既存のboiler-templateと同じように、microCMSでもNILTOでも詳細ページを表示できるようにする
#### 残件
- [ ] デザイナーさんのデザイン作成後、そのデザインを参照してテンプレートを複数作成する
- [ ] 作成したテンプレートを使って表示できるようにする
### #13 詳細ページ - 記事中にサムネイルを表示する
#### このPRでできていること
- [x] 既存のboiler-templateと同じように、microCMSでもNILTOでもサムネイルを表示できるようにする
#### 残件
- [ ] デザイナーさんのデザイン作成後、そのデザインを参照して表示できるようにする

### #14 詳細ページ - 記事最下部に関連記事（サムネールあり）をつける
#### このPRでできていること
- [x] 既存のboiler-templateと同じように、microCMSでもNILTOでもサムネイルを表示できるようにする
#### 残件
- [ ] デザイナーさんのデザイン作成後、そのデザインを参照して表示できるようにする

## 事象
記事詳細ページにおいて、NILTOでもmicroCMSでも同じUI表示実装で切り替えることができるようにしたい。

## やったこと
- 記事詳細ページ(app/articles/[slug]/page.tsx)
  - `getArticleDetail`関数(microCMSからデータ取得する関数)を使っていた部分を、`fetchArticleDetailData`関数(microCMS or NILTOからデータ取得、変換して返す関数)を使うように変更
- Cardコンポーネント/Cardsコンポーネント
  - 記事詳細ページ以外でも使用するため、microCMS用の型を残したまま、microCMS,NILTOで使える型も追加
- Categoryコンポーネント/Tagコンポーネント/Tagsコンポーネント
  - 記事詳細ページでしか関係ないため、microCMS用の型を削除し、microCMS,NILTOで使える型に変更
- [anti-corruption-layer/articleDetail.ts](https://github.com/sun-asterisk-training/headlesscms-app-boiler-plate/compare/feature/nilto-fetch-and-display-article-details?expand=1#diff-62be02c319f78d24ceedd9771248a1a0e05f5b857c7dc293383ee49020587ab6)
  - 記事詳細ページにおいてmicroCMS or NILTOからデータ取得し、データを変換して返すための関数、型を記述
- [nilto/articleDetail.ts](https://github.com/sun-asterisk-training/headlesscms-app-boiler-plate/compare/feature/nilto-fetch-and-display-article-details?expand=1#diff-42b81f29fb47579986b970ff4b5bdf88a9f28d426c0f37bd7e4f69cfe24ba345)
  - NILTOから記事詳細のデータを取得するための関数、型を記述
- [_libs/utils.ts](https://github.com/sun-asterisk-training/headlesscms-app-boiler-plate/compare/feature/nilto-fetch-and-display-article-details?expand=1#diff-981146f6ad24d4586aa44c1c19768055f7964fd527aeb7e856518d12545b3f63)
  - 必要な型と変数を追記
- next.config.jsにniltoから画像を取得するためにdomainsを追加

## やってないこと
- インデントが変更に含まれてしまっていますが、このあたりのルールが決めれられていないということもあり、一旦対応はしていないです。
- ディレクトリ構成についても決めれられていないので、_libs配下のフォルダの追加等は適当に行っています。

## 動作確認 (※キャプチャは全体を写せるように画面を縮小しています)
### microCMSで存在するコンテンツIDで記事詳細ページへアクセスし、表示できることを確認
![スクリーンショット 2024-07-23 16 22 48](https://github.com/user-attachments/assets/13665aca-2661-4582-85b9-6e354937916c)

### NILTOで存在するコンテンツIDで記事詳細ページへアクセスし、表示できることを確認
![スクリーンショット 2024-07-23 16 26 31](https://github.com/user-attachments/assets/bcd52f05-df67-4e33-9874-8275b65913c3)

## 補足
READ MEに、現時点での`.env.local`の設定を追記しました。