### PR TITLE
[トップページ] NILTOでもmicroCMSと同じように記事一覧を表示できるようにする

### DIFF
--- a/app/_components/List/index.tsx
+++ b/app/_components/List/index.tsx
@@ -1,11 +1,11 @@
 import Link from 'next/link';
 import Image from 'next/image';
-import { Article } from '@/_libs/microcms';
+import { TransformedArticleDetailResponse } from '@/_libs/anti-corruption-layer/articleDetail';
 import PublishDate from '@/_components/PublishDate';
 import styles from './index.module.css';
 
 type Props = {
-  article: Article;
+  article: TransformedArticleDetailResponse;
 };
 
 export default function List({ article }: Props) {

--- a/app/_components/Pickup/index.tsx
+++ b/app/_components/Pickup/index.tsx
@@ -1,4 +1,4 @@
-import { getPickup } from '@/_libs/microcms';
+import { fetchPickupData } from '@/_libs/anti-corruption-layer/pickup';
 import { RANKING_LIMIT } from '@/_constants';
 import List from '@/_components/List';
 
@@ -7,10 +7,7 @@ type Props = {
 };
 
 export default async function Pickup({ draftKey }: Props) {
-  const data = await getPickup({
-    limit: RANKING_LIMIT,
-    draftKey,
-  }).catch(() => ({ articles: [] }));
+  const data = await fetchPickupData(RANKING_LIMIT, draftKey).catch(() => ({ articles: [] }));
   const articles = data.articles;
   return (
     <div>

--- a/app/_components/Ranking/index.tsx
+++ b/app/_components/Ranking/index.tsx
@@ -1,4 +1,4 @@
-import { getRanking } from '@/_libs/microcms';
+import { fetchRankingData } from '@/_libs/anti-corruption-layer/ranking';
 import { RANKING_LIMIT } from '@/_constants';
 import List from '@/_components/List';
 
@@ -7,10 +7,7 @@ type Props = {
 };
 
 export default async function Ranking({ draftKey }: Props) {
-  const data = await getRanking({
-    limit: RANKING_LIMIT,
-    draftKey,
-  }).catch(() => ({ articles: [] }));
+  const data = await fetchRankingData(RANKING_LIMIT, draftKey).catch(() => ({ articles: [] }));
   const articles = data.articles;
   return (
     <div>

--- a/app/_components/ReadMore/index.module.css
+++ b/app/_components/ReadMore/index.module.css
@@ -1,0 +1,7 @@
+.readMore {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin: 32px 0;
+}

--- a/app/_components/ReadMore/index.tsx
+++ b/app/_components/ReadMore/index.tsx
@@ -1,9 +1,12 @@
 'use client';
 
 import { FC, useState, useCallback } from 'react';
-import { getArticleList, Article } from '@/_libs/microcms';
+import { fetchArticleListData } from '@/_libs/anti-corruption-layer/articleList';
+import { TransformedArticleDetailResponse } from '@/_libs/anti-corruption-layer/articleDetail';
 import { LIMIT } from '@/_constants';
 import Cards from '@/_components/Cards';
+import { Button } from '@mui/material';
+import styles from './index.module.css';
 
 type Props = {
   filters?: string;
@@ -12,15 +15,10 @@ type Props = {
 };
 
 export const ReadMore: FC<Props> = ({ filters, q, totalCount }) => {
-  const [contents, setContents] = useState<Article[]>([]);
+  const [contents, setContents] = useState<TransformedArticleDetailResponse[]>([]);
   const [offset, setOffset] = useState<number>(LIMIT);
   const getNextContents = useCallback(async () => {
-    const data = await getArticleList({
-      limit: LIMIT,
-      offset,
-      filters,
-      q,
-    });
+    const data = await fetchArticleListData(LIMIT, offset, filters, q);
     setContents((prev) => [...prev, ...data.contents]);
     setOffset((prev) => prev + LIMIT);
   }, [offset, filters, q]);
@@ -30,9 +28,13 @@ export const ReadMore: FC<Props> = ({ filters, q, totalCount }) => {
   }
 
   return (
-    <div>
-      <Cards articles={contents} />
-      {totalCount > offset && <button onClick={getNextContents}>もっと読む</button>}
+    <div className={styles.readMore}>
+      {contents.length > 0 && <Cards articles={contents} />}
+      {totalCount > offset && (
+        <Button variant="outlined" onClick={getNextContents}>
+          もっと読む
+        </Button>
+      )}
     </div>
   );
 };

--- a/app/_constants/index.ts
+++ b/app/_constants/index.ts
@@ -6,3 +6,9 @@ export const RANKING_LIMIT = 5;
 
 // サイトマップの件数
 export const SITEMAP_LIMIT = 100;
+
+// サービス名を表す定数
+export enum CMS {
+  MICROCMS = 'microcms',
+  NILTO = 'nilto',
+}

--- a/app/_libs/anti-corruption-layer/articleDetail.ts
+++ b/app/_libs/anti-corruption-layer/articleDetail.ts
@@ -1,6 +1,7 @@
 import { Article, getArticleDetail } from '../microcms';
 import { ArticleDetailResponse, fetchArticleDetail } from '../nilto/articleDetail';
 import { TYPE_CMS, TypeCMS } from '../utils';
+import { CMS } from '@/_constants';
 
 const THUMBNAIL_WIDTH = 800;
 const THUMBNAIL_HEIGHT = 600;
@@ -49,9 +50,9 @@ export const fetchArticleDetailCMSData = async (
   draftKey?: string,
 ) => {
   switch (typeCMS) {
-    case 'nilto':
+    case CMS.NILTO:
       return await fetchArticleDetail(id);
-    case 'microcms':
+    case CMS.MICROCMS:
       return await getArticleDetail(id, {
         draftKey: draftKey,
       });
@@ -70,7 +71,9 @@ const createThumbnail = (
   height,
 });
 
-const transformNiltoData = (niltoData: ArticleDetailResponse): TransformedArticleDetailResponse => {
+export const transformNiltoData = (
+  niltoData: ArticleDetailResponse,
+): TransformedArticleDetailResponse => {
   const thumbnail = niltoData.thumbnail ? createThumbnail(niltoData.thumbnail.url) : null;
 
   const category = niltoData.category
@@ -133,7 +136,7 @@ const transformNiltoData = (niltoData: ArticleDetailResponse): TransformedArticl
   };
 };
 
-const transformMicroCMSData = (microCMSData: Article): TransformedArticleDetailResponse => {
+export const transformMicroCMSData = (microCMSData: Article): TransformedArticleDetailResponse => {
   const thumbnail = microCMSData.thumbnail
     ? createThumbnail(
         microCMSData.thumbnail.url,
@@ -186,9 +189,9 @@ export const transformResponse = (
   typeCMS: TypeCMS,
 ): TransformedArticleDetailResponse => {
   switch (typeCMS) {
-    case 'nilto':
+    case CMS.NILTO:
       return transformNiltoData(data as ArticleDetailResponse);
-    case 'microcms':
+    case CMS.MICROCMS:
       return transformMicroCMSData(data as Article);
     default:
       throw new Error('Unsupported CMS type');

--- a/app/_libs/anti-corruption-layer/articleList.ts
+++ b/app/_libs/anti-corruption-layer/articleList.ts
@@ -1,0 +1,91 @@
+import { MicroCMSListResponse } from 'microcms-js-sdk';
+import { Article, getArticleList } from '../microcms';
+import { ArticleListResponse, fetchArticleList } from '../nilto/articleList';
+import { TYPE_CMS, TypeCMS } from '../utils';
+import { CMS } from '@/_constants';
+import {
+  TransformedArticleDetailResponse,
+  transformNiltoData,
+  transformMicroCMSData,
+} from './articleDetail';
+
+// 記事一覧の型定義
+export type TransformedArticleListResponse = {
+  totalCount: number;
+  limit: number;
+  offset: number;
+  contents: TransformedArticleDetailResponse[];
+};
+
+// 指定されたCMSから記事一覧を取得する
+export const fetchArticleListCMSData = async (
+  typeCMS: TypeCMS,
+  limit: number,
+  offset?: number,
+  filters?: string,
+  q?: string,
+) => {
+  switch (typeCMS) {
+    case CMS.NILTO:
+      return await fetchArticleList(limit, offset); // TODO: filters, q は未対応
+    case CMS.MICROCMS:
+      return await getArticleList({
+        limit,
+        offset,
+        filters,
+        q,
+      });
+    default:
+      throw new Error('Unsupported CMS type');
+  }
+};
+
+const transformNiltoListData = (niltoData: ArticleListResponse): TransformedArticleListResponse => {
+  return {
+    totalCount: niltoData.total,
+    limit: niltoData.limit,
+    offset: niltoData.offset,
+    contents: niltoData.data.map((article) => transformNiltoData(article)),
+  };
+};
+
+const transformMicroCMSListData = (
+  microCMSData: MicroCMSListResponse<Article>,
+): TransformedArticleListResponse => {
+  return {
+    totalCount: microCMSData.totalCount,
+    limit: microCMSData.limit,
+    offset: microCMSData.offset,
+    contents: microCMSData.contents.map((article) => transformMicroCMSData(article)),
+  };
+};
+
+export const transformResponse = (
+  data: ArticleListResponse | MicroCMSListResponse<Article>,
+  typeCMS: TypeCMS,
+): TransformedArticleListResponse => {
+  switch (typeCMS) {
+    case CMS.NILTO:
+      return transformNiltoListData(data as ArticleListResponse);
+    case CMS.MICROCMS:
+      return transformMicroCMSListData(data as MicroCMSListResponse<Article>);
+    default:
+      throw new Error('Unsupported CMS type');
+  }
+};
+
+// 記事一覧を取得してデータを変換して返す
+export const fetchArticleListData = async (
+  limit: number,
+  offset?: number,
+  filters?: string,
+  q?: string,
+): Promise<TransformedArticleListResponse> => {
+  const response = await fetchArticleListCMSData(TYPE_CMS, limit, offset, filters, q);
+
+  if (!response) {
+    throw new Error('Failed to fetch article list');
+  }
+
+  return transformResponse(response, TYPE_CMS);
+};

--- a/app/_libs/anti-corruption-layer/pickup.ts
+++ b/app/_libs/anti-corruption-layer/pickup.ts
@@ -1,0 +1,70 @@
+import { Pickup, getPickup } from '../microcms';
+import { fetchPickup, PickupResponse } from '../nilto/pickup';
+import { TYPE_CMS, TypeCMS } from '../utils';
+import { CMS } from '@/_constants';
+import {
+  TransformedArticleDetailResponse,
+  transformNiltoData,
+  transformMicroCMSData,
+} from './articleDetail';
+
+// ピックアップの型定義
+export type TransformedPickupResponse = {
+  articles: TransformedArticleDetailResponse[];
+};
+
+// 指定されたCMSからピックアップを取得する
+export const fetchPickupCMSData = async (typeCMS: TypeCMS, limit: number, draftKey?: string) => {
+  switch (typeCMS) {
+    case CMS.NILTO:
+      return await fetchPickup(limit);
+    case CMS.MICROCMS:
+      return await getPickup({
+        limit,
+        draftKey,
+        depth: 2, // MEMO: depth=1がデフォルトで、idのみ取得され、2にすると詳細も取得される
+      });
+    default:
+      throw new Error('Unsupported CMS type');
+  }
+};
+
+const transformNiltoPickupData = (niltoData: PickupResponse): TransformedPickupResponse => {
+  return {
+    articles: niltoData.data.map((data) => transformNiltoData(data.article)),
+  };
+};
+
+const transformMicroCMSPickupData = (microCMSData: Pickup): TransformedPickupResponse => {
+  return {
+    articles: microCMSData.articles.map((data) => transformMicroCMSData(data)),
+  };
+};
+
+export const transformResponse = (
+  data: PickupResponse | Pickup,
+  typeCMS: TypeCMS,
+): TransformedPickupResponse => {
+  switch (typeCMS) {
+    case CMS.NILTO:
+      return transformNiltoPickupData(data as PickupResponse);
+    case CMS.MICROCMS:
+      return transformMicroCMSPickupData(data as Pickup);
+    default:
+      throw new Error('Unsupported CMS type');
+  }
+};
+
+// ピックアップを取得してデータを変換して返す
+export const fetchPickupData = async (
+  limit: number,
+  draftKey?: string,
+): Promise<TransformedPickupResponse> => {
+  const response = await fetchPickupCMSData(TYPE_CMS, limit, draftKey);
+
+  if (!response) {
+    throw new Error('Failed to fetch pickup');
+  }
+
+  return transformResponse(response, TYPE_CMS);
+};

--- a/app/_libs/anti-corruption-layer/ranking.ts
+++ b/app/_libs/anti-corruption-layer/ranking.ts
@@ -1,0 +1,70 @@
+import { Ranking, getRanking } from '../microcms';
+import { fetchRanking, RankingResponse } from '../nilto/ranking';
+import { TYPE_CMS, TypeCMS } from '../utils';
+import { CMS } from '@/_constants';
+import {
+  TransformedArticleDetailResponse,
+  transformNiltoData,
+  transformMicroCMSData,
+} from './articleDetail';
+
+// ランキングの型定義
+export type TransformedRankingResponse = {
+  articles: TransformedArticleDetailResponse[];
+};
+
+// 指定されたCMSからランキングを取得する
+export const fetchRankingCMSData = async (typeCMS: TypeCMS, limit: number, draftKey?: string) => {
+  switch (typeCMS) {
+    case CMS.NILTO:
+      return await fetchRanking(limit);
+    case CMS.MICROCMS:
+      return await getRanking({
+        limit,
+        draftKey,
+        depth: 2, // MEMO: depth=1がデフォルトで、idのみ取得され、2にすると詳細も取得される
+      });
+    default:
+      throw new Error('Unsupported CMS type');
+  }
+};
+
+const transformNiltoRankingData = (niltoData: RankingResponse): TransformedRankingResponse => {
+  return {
+    articles: niltoData.data.map((data) => transformNiltoData(data.article)),
+  };
+};
+
+const transformMicroCMSRankingData = (microCMSData: Ranking): TransformedRankingResponse => {
+  return {
+    articles: microCMSData.articles.map((data) => transformMicroCMSData(data)),
+  };
+};
+
+export const transformResponse = (
+  data: RankingResponse | Ranking,
+  typeCMS: TypeCMS,
+): TransformedRankingResponse => {
+  switch (typeCMS) {
+    case CMS.NILTO:
+      return transformNiltoRankingData(data as RankingResponse);
+    case CMS.MICROCMS:
+      return transformMicroCMSRankingData(data as Ranking);
+    default:
+      throw new Error('Unsupported CMS type');
+  }
+};
+
+// ランキングを取得してデータを変換して返す
+export const fetchRankingData = async (
+  limit: number,
+  draftKey?: string,
+): Promise<TransformedRankingResponse> => {
+  const response = await fetchRankingCMSData(TYPE_CMS, limit, draftKey);
+
+  if (!response) {
+    throw new Error('Failed to fetch ranking');
+  }
+
+  return transformResponse(response, TYPE_CMS);
+};

--- a/app/_libs/nilto/articleList.ts
+++ b/app/_libs/nilto/articleList.ts
@@ -1,0 +1,48 @@
+import { ArticleDetailResponse } from './articleDetail';
+
+export type ArticleListResponse = {
+  total: number;
+  limit: number;
+  offset: number;
+  data: ArticleDetailResponse[];
+};
+
+const baseUrl = process.env.NEXT_PUBLIC_NILTO_BASE_URL;
+const apiKey = process.env.NEXT_PUBLIC_NILTO_API_KEY;
+
+if (!baseUrl) {
+  throw new Error('NEXT_PUBLIC_NILTO_BASE_URL is required');
+}
+
+if (!apiKey) {
+  throw new Error('NEXT_PUBLIC_NILTO_API_KEY is required');
+}
+
+export const fetchArticleList = async (
+  limit: number,
+  offset?: number,
+): Promise<ArticleListResponse | null> => {
+  try {
+    const headers = new Headers();
+    headers.append('X-NILTO-API-KEY', apiKey);
+
+    const params = new URLSearchParams({
+      model: 'articles',
+      limit: limit.toString(),
+      offset: offset?.toString() || '0',
+    });
+
+    const response = await fetch(`${baseUrl}contents?${params.toString()}`, {
+      headers: headers,
+    });
+
+    if (!response) {
+      throw new Error('Failed to fetch article list');
+    }
+
+    const data: ArticleListResponse = await response.json();
+    return data;
+  } catch (error) {
+    return null;
+  }
+};

--- a/app/_libs/nilto/pickup.ts
+++ b/app/_libs/nilto/pickup.ts
@@ -1,0 +1,44 @@
+import { ArticleDetailResponse } from './articleDetail';
+
+export type PickupResponse = {
+  data: {
+    article: ArticleDetailResponse;
+  }[];
+};
+
+const baseUrl = process.env.NEXT_PUBLIC_NILTO_BASE_URL;
+const apiKey = process.env.NEXT_PUBLIC_NILTO_API_KEY;
+
+if (!baseUrl) {
+  throw new Error('NEXT_PUBLIC_NILTO_BASE_URL is required');
+}
+
+if (!apiKey) {
+  throw new Error('NEXT_PUBLIC_NILTO_API_KEY is required');
+}
+
+export const fetchPickup = async (limit: number): Promise<PickupResponse | null> => {
+  try {
+    const headers = new Headers();
+    headers.append('X-NILTO-API-KEY', apiKey);
+
+    const params = new URLSearchParams({
+      model: 'pickup',
+      limit: limit.toString(),
+      depth: '2', // MEMO: depth=1がデフォルトで、idのみ取得され、2にすると詳細も取得される
+    });
+
+    const response = await fetch(`${baseUrl}contents?${params.toString()}`, {
+      headers: headers,
+    });
+
+    if (!response) {
+      throw new Error('Failed to fetch pickup');
+    }
+
+    const data: PickupResponse = await response.json();
+    return data;
+  } catch (error) {
+    return null;
+  }
+};

--- a/app/_libs/nilto/ranking.ts
+++ b/app/_libs/nilto/ranking.ts
@@ -1,0 +1,44 @@
+import { ArticleDetailResponse } from './articleDetail';
+
+export type RankingResponse = {
+  data: {
+    article: ArticleDetailResponse;
+  }[];
+};
+
+const baseUrl = process.env.NEXT_PUBLIC_NILTO_BASE_URL;
+const apiKey = process.env.NEXT_PUBLIC_NILTO_API_KEY;
+
+if (!baseUrl) {
+  throw new Error('NEXT_PUBLIC_NILTO_BASE_URL is required');
+}
+
+if (!apiKey) {
+  throw new Error('NEXT_PUBLIC_NILTO_API_KEY is required');
+}
+
+export const fetchRanking = async (limit: number): Promise<RankingResponse | null> => {
+  try {
+    const headers = new Headers();
+    headers.append('X-NILTO-API-KEY', apiKey);
+
+    const params = new URLSearchParams({
+      model: 'ranking',
+      limit: limit.toString(),
+      depth: '2', // MEMO: depth=1がデフォルトで、idのみ取得され、2にすると詳細も取得される
+    });
+
+    const response = await fetch(`${baseUrl}contents?${params.toString()}`, {
+      headers: headers,
+    });
+
+    if (!response) {
+      throw new Error('Failed to fetch ranking');
+    }
+
+    const data: RankingResponse = await response.json();
+    return data;
+  } catch (error) {
+    return null;
+  }
+};

--- a/app/_libs/utils.ts
+++ b/app/_libs/utils.ts
@@ -1,9 +1,10 @@
 import { format } from 'date-fns';
 import { utcToZonedTime } from 'date-fns-tz';
+import { CMS } from '@/_constants';
 
 export const TYPE_CMS = process.env.NEXT_PUBLIC_TYPE_CMS as TypeCMS;
 
-export type TypeCMS = 'nilto' | 'microcms';
+export type TypeCMS = CMS.NILTO | CMS.MICROCMS;
 
 export const formatDate = (date: string) => {
   const utcDate = new Date(date);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import Main from '@/_components/Main';
 import Sub from '@/_components/Sub';
 import Ad from '@/_components/Ad';
 import { LIMIT } from '@/_constants';
-import { getArticleList } from '@/_libs/microcms';
+import { fetchArticleListData } from '@/_libs/anti-corruption-layer/articleList';
 import Cards from '@/_components/Cards';
 import Ranking from '@/_components/Ranking';
 import SearchField from '@/_components/SearchField';
@@ -20,9 +20,7 @@ type Props = {
 };
 
 export default async function Page({ searchParams }: Props) {
-  const data = await getArticleList({
-    limit: LIMIT,
-  });
+  const data = await fetchArticleListData(LIMIT);
   return (
     <Layout>
       <Main>


### PR DESCRIPTION
## 関連Issue
### #8 トップページ - 今日のニュース一覧を表示する
#### このPRでできていること
- [x] 既存のboiler-templateと同じように、microCMSでもNILTOでも記事一覧を表示できるようにする
#### 残件
- [ ] デザイナーさんのデザイン作成後、そのデザインを参照して表示できるようにする

### #9 トップページ - 注目のニュース一覧を表示する
#### このPRでできていること
- [x] 既存のboiler-templateと同じように、microCMSでもNILTOでも注目の記事一覧を表示できるようにする
#### 残件
- [ ] デザイナーさんのデザイン作成後、そのデザインを参照して表示できるようにする

## 事象
トップページにおいて、NILTOでもmicroCMSでも同じUI表示実装で切り替えることができるようにしたい。

## やったこと
- トップページ (app/page.tsx) / Pickupコンポーネント / Rankingコンポーネント / ReadMoreコンポーネント
  - `getArticleList` 関数(microCMSからデータ取得する関数)を使っていた部分を、`fetchArticleListData`関数(microCMS or NILTOからデータ取得、変換して返す関数)を使うように変更
  - 同様に、`getPickup` 関数と`getRanking` 関数を `fetchPickupData` 関数と`fetchRankingData` 関数を使うように変更
- Listコンポーネント
  - microCMS用の型を削除し、microCMS,NILTOで使える型に変更
- _libs/anti-corruption-layer
  - `articleDetail.ts` を基にして、`articleList.ts` と `pickup.ts` と `ranking.ts` を作成
  - トップページにおいてmicroCMS or NILTOからデータ取得し、データを変換して返すための関数、型を記述
- _libs/nilto
  - `articleDetail.ts` を基にして、`articleList.ts` と `pickup.ts` と `ranking.ts` を作成
  - NILTOから記事詳細のデータを取得するための関数、型を記述
- _contants/index.ts
  - サービス名を表す定数 (enum) を追加
  - `_libs/utils.ts` と `anti-corruption-layer/articleDetail.ts`で通常の文字列の代わりに定数を使用
- ReadMoreコンポーネント
  - 表示を改善するためにCSSを追加し、ボタン「もっと読む」にMUIを使用

## やってないこと
- `fetchArticleListData` 関数の (`filters` と `q`) 変数はまだ NILTO の `fetchArticleList` 関数に渡されていないので、一旦対応していません。

## 動作確認
### microCMSで存在するコンテンツでトップページへアクセスし、表示できることを確認
![screencapture-localhost-3002-2024-08-02-17_19_19](https://github.com/user-attachments/assets/bd12bc9e-dc0b-4824-b256-d3232214192b)

### NILTOで存在するコンテンツでトップページへアクセスし、表示できることを確認
![screencapture-localhost-3002-2024-08-02-17_19_53](https://github.com/user-attachments/assets/5c5c4b27-3629-42a2-bdd7-f60e9222d5e8)
