### PR TITLE
[issue-15] 分析ツール実装

### DIFF
--- a/app/_components/GTM/index.tsx
+++ b/app/_components/GTM/index.tsx
@@ -1,12 +1,25 @@
-'use client';
+import Script from 'next/script'
 
-import { FC, useEffect } from 'react';
-import TagManager from 'react-gtm-module';
+interface GTMProps {
+  gtmId: string
+}
 
-export const GTM: FC = () => {
-  useEffect(() => {
-    TagManager.initialize({ gtmId: process.env.NEXT_PUBLIC_GTM_ID as string });
-  }, []);
-
-  return null;
-};
+export default function GTM({ gtmId }: GTMProps) {
+  return (
+      <>
+        <Script
+            id="gtm-script"
+            strategy="afterInteractive"
+            dangerouslySetInnerHTML={{
+              __html: `
+            (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+            })(window,document,'script','dataLayer', '${gtmId}');
+          `,
+            }}
+        />
+      </>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,47 +1,57 @@
-import type { Metadata } from 'next';
-// import Script from 'next/script';
+import type {Metadata} from 'next';
 import './globals.css';
 import Header from '@/_components/Header';
-import { GTM } from '@/_components/GTM';
+import GTM from '@/_components/GTM';
 
 export const metadata: Metadata = {
-  metadataBase: new URL(process.env.BASE_URL as string),
-  title: {
-    template: '%s｜公式メディアテンプレート',
-    default: '公式メディアテンプレート',
-  },
-  description: 'Next.js製のメディア向けスケルトンテンプレートです',
-  openGraph: {
-    title: '公式メディアテンプレート',
+    metadataBase: new URL(process.env.BASE_URL as string),
+    title: {
+        template: '%s｜公式メディアテンプレート',
+        default: '公式メディアテンプレート',
+    },
     description: 'Next.js製のメディア向けスケルトンテンプレートです',
-    type: 'website',
-    images: '/ogp.png',
-  },
-  twitter: {
-    card: 'summary_large_image',
-  },
-  alternates: {
-    canonical: '/',
-  },
+    openGraph: {
+        title: '公式メディアテンプレート',
+        description: 'Next.js製のメディア向けスケルトンテンプレートです',
+        type: 'website',
+        images: '/ogp.png',
+    },
+    twitter: {
+        card: 'summary_large_image',
+    },
+    alternates: {
+        canonical: '/',
+    },
 };
 
-const isProduction: boolean = process.env.NODE_ENV === 'production';
+// const isProduction: boolean = process.env.NODE_ENV === 'production';
+const gtmId = process.env.NEXT_PUBLIC_GTM_ID || ''
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <html lang="ja">
-      {/* {isProduction && (
+export default function RootLayout({children}: { children: React.ReactNode }) {
+    return (
+        <html lang="ja">
+        <head>
+            <GTM gtmId={gtmId}/>
+        </head>
+        {/* {isProduction && (
         <Script
           async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-0000000000000000"
           crossOrigin="anonymous"
         />
       )} */}
-      {isProduction && <GTM />}
-      <body>
-        <Header />
+        <body>
+        <noscript>
+            <iframe
+                src={`https://www.googletagmanager.com/ns.html?id=${gtmId}`}
+                height="0"
+                width="0"
+                style={{display: 'none', visibility: 'hidden'}}
+            />
+        </noscript>
+        <Header/>
         {children}
-      </body>
-    </html>
-  );
+        </body>
+        </html>
+    );
 }


### PR DESCRIPTION
# 関連issue
#15 
# 実装内容
テンプレで実装されていたGTM/index.tsxはreact-gtm-moduleを使用していたが、更新が止まっておりGTMが想定通りに動作しなかった。そのためGTM/index.tsxに直接Scriptを書くことにした。
(参考: https://github.com/alinemorelli/react-gtm/issues/132)

GTMを用いることで、ほとんどのイベントを全てGTM上で管理・作成できる。作成できたものから黄色🟨で塗りつぶしている
https://docs.google.com/spreadsheets/d/1aIQUrQJnaSGfY9RUk6xLzJSMIxcqqStwix6L1RMK89E/edit?usp=sharing
いくつかの分析項目はデータ取得に半日ほどかかるため、進行中

# テスト
- テスト用に、このリポジトリを自分のプライベートリポジトリにForkし、Vercelにデプロイした。
[headlesscms-boiler-plate-fork.vercel.app](https://headlesscms-boiler-plate-fork.vercel.app/)
- .envに環境変数 ` NEXT_PUBLIC_GTM_ID=GTM-xxxxxx ` を設定するとTag Assistantで動作することを確認
- https://tagassistant.google.com/ にURLを打ち込み、GTMのタグがGA4の測定IDと紐づいていることを確認、イベントの取得も確認
- GA4の画面で実際にアナリティクスが更新されていることを確認

# 不具合・相談事項
**検索**
おそらくフロントの検索キーワードの実装に不具合があり、検索しても結果がundefinedになる。これにより、検索イベントは検知できてるが検索キーワードの集計ができてない
**広告**
広告クリックは、広告をどのように配信するか検討する必要がある。Google広告を使用する場合、GA4と連携はしやすく、データの表示がすぐにできる
