### PR TITLE
NILTO webhookとTwitterAPIを用いたX自動投稿の実装

### DIFF
--- a/app/api/tweet/route.ts
+++ b/app/api/tweet/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { TwitterApi } from 'twitter-api-v2';
+
+export async function POST(request: Request) {
+  // console.log('API Key exists:', !!process.env.TWITTER_API_KEY);
+  // console.log('API Secret exists:', !!process.env.TWITTER_API_SECRET);
+  // console.log('Access Token exists:', !!process.env.TWITTER_ACCESS_TOKEN);
+  // console.log('Access Secret exists:', !!process.env.TWITTER_ACCESS_SECRET);
+
+  try {
+    // console.log('Initializing Twitter client...');
+    const client = new TwitterApi({
+      appKey: process.env.TWITTER_API_KEY!,
+      appSecret: process.env.TWITTER_API_SECRET!,
+      accessToken: process.env.TWITTER_ACCESS_TOKEN!,
+      accessSecret: process.env.TWITTER_ACCESS_SECRET!,
+    });
+
+    // console.log('Twitter client initialized. Attempting to tweet...');
+    const tweet = await client.v2.tweet('NILTOのコンテンツが更新されました(これはtestです)');
+    // console.log('Tweet sent successfully:', tweet);
+
+    return NextResponse.json({ message: 'Tweet sent successfully', tweet }, { status: 200 });
+  } catch (error: any) {
+    // console.error('Error sending tweet:', error.message);
+    // console.error('Full error object:', JSON.stringify(error, null, 2));
+    return NextResponse.json(
+      { error: error.message, details: JSON.stringify(error, null, 2) },
+      { status: 500 },
+    );
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-gtm-module": "^2.0.11",
+        "twitter-api-v2": "^1.18.0",
         "typescript": "5.1.6"
       },
       "engines": {
@@ -4506,6 +4507,11 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+    },
+    "node_modules/twitter-api-v2": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/twitter-api-v2/-/twitter-api-v2-1.18.0.tgz",
+      "integrity": "sha512-dhrj9wV2qQnHqlbFzt9qpb3mdK1oFcK3llFUnlFe8al19SrXlF3jHk3Y42wT0VRtF9LwpUeJ4QdHiqAiDgrTrg=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-gtm-module": "^2.0.11",
+    "twitter-api-v2": "^1.18.0",
     "typescript": "5.1.6"
   }
 }


### PR DESCRIPTION
## 実装概要
- `api/tweet/route.ts`
  - Xに投稿するための実装
- `npm install twitter-api-v2`を実施

## 補足
### envファイル、vercelに必要な環境変数を記述しましょう
```
TWITTER_API_KEY=xxxxxxxxxxxxxxxxxxxx
TWITTER_API_SECRET=xxxxxxxxxxxxxxxxxxxx
TWITTER_ACCESS_TOKEN=xxxxxxxxxxxxxxxxxxxx
TWITTER_ACCESS_SECRET=xxxxxxxxxxxxxxxxxxxx
```

### NILTOでwebhookを指定する必要があります
(例)
![スクリーンショット 2024-10-17 13 40 31](https://github.com/user-attachments/assets/d5e25caf-d67f-4a44-9503-b5b81f4137cc)
